### PR TITLE
Fix variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ privoxy_connection_sharing: false
 privoxy_debug:
   - 0
 privoxy_default_server_timeout: 60
+privoxy_deny_access: []
 privoxy_enable_compression: false
 privoxy_enable_edit_actions: false
 privoxy_enable_remote_toggle: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   tags: privoxy
   template:
     src: config.j2
-    dest: /usr/local/etc/privoxy/config
+    dest: "{{ privoxy_confdir }}/config"
     owner: "{{ ansible_real_user_id }}"
     group: "{{ ansible_real_group_id }}"
     mode: 0640


### PR DESCRIPTION
1. Here is an error with `privoxy_deny_access` not found:
https://github.com/tkimball83/ansible-role-privoxy/blob/fc03b6020494c90e44ff7e99243b49dc7c901f78/templates/config.j2#L74

1. The config file should be placed in privoxy_confdir.