### PR TITLE
Add support for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Available variables are listed below, along with default values:
     privoxy_buffer_limit: 4096
     privoxy_client_header_order: []
     privoxy_compression_level: 1
-    privoxy_confdir: /usr/local/etc/privoxy
     privoxy_connection_sharing: false
     privoxy_debug:
       - 0
@@ -48,7 +47,6 @@ Available variables are listed below, along with default values:
     privoxy_hostname: "{{ inventory_hostname }}"
     privoxy_keep_alive_timeout: 5
     privoxy_listen_address: '127.0.0.1:8118'
-    privoxy_logdir: /usr/local/var/log/privoxy
     privoxy_logfile: logfile
     privoxy_max_client_connections: 128
     privoxy_permit_access: []
@@ -62,7 +60,6 @@ Available variables are listed below, along with default values:
     privoxy_tolerate_pipelining: true
     privoxy_trust_info_url: []
     privoxy_trustfile: ''
-    privoxy_user_manual: /usr/local/share/doc/privoxy/user-manual
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,6 @@ privoxy_allow_cgi_request_crunching: false
 privoxy_buffer_limit: 4096
 privoxy_client_header_order: []
 privoxy_compression_level: 1
-privoxy_confdir: /usr/local/etc/privoxy
 privoxy_connection_sharing: false
 privoxy_debug:
   - 0
@@ -34,7 +33,6 @@ privoxy_handle_as_empty_doc_returns_ok: false
 privoxy_hostname: "{{ inventory_hostname }}"
 privoxy_keep_alive_timeout: 5
 privoxy_listen_address: '127.0.0.1:8118'
-privoxy_logdir: /usr/local/var/log/privoxy
 privoxy_logfile: logfile
 privoxy_max_client_connections: 128
 privoxy_permit_access: []
@@ -48,5 +46,4 @@ privoxy_toggle: true
 privoxy_tolerate_pipelining: true
 privoxy_trust_info_url: []
 privoxy_trustfile: ''
-privoxy_user_manual: /usr/local/share/doc/privoxy/user-manual
 ...

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,11 +3,14 @@ dependencies: []
 galaxy_info:
   role_name: privoxy
   author: tkimball83
-  description: macOS - A non-caching web proxy
+  description: A non-caching web proxy
   license: GPLv3
   min_ansible_version: 2.7
   platforms:
     - name: MacOSX
+      versions:
+        - all
+    - name: Ubuntu
       versions:
         - all
   galaxy_tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - include_vars: "{{ ansible_os_family }}.yml"
 
-- include: "setup-{{ ansible_os_family }}.yml"
+- include_tasks: "setup-{{ ansible_os_family }}.yml"
 
 - name: Attempting to overlay privoxy configurations
   tags: privoxy

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,14 @@
 ---
-- name: Ensure that the privoxy package is installed
-  tags: privoxy
-  homebrew:
-    name: privoxy
-    state: present
+- include_vars: "{{ ansible_os_family }}.yml"
+
+- include: "setup-{{ ansible_os_family }}.yml"
 
 - name: Attempting to overlay privoxy configurations
   tags: privoxy
   template:
     src: config.j2
     dest: "{{ privoxy_confdir }}/config"
-    owner: "{{ ansible_real_user_id }}"
-    group: "{{ ansible_real_group_id }}"
+    owner: "{{ privoxy_user }}"
+    group: "{{ privoxy_group }}"
     mode: 0640
 ...

--- a/tasks/setup-Darwin.yml
+++ b/tasks/setup-Darwin.yml
@@ -1,0 +1,7 @@
+---
+- name: Ensure that the privoxy package is installed
+  tags: privoxy
+  homebrew:
+    name: privoxy
+    state: present
+...

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,0 +1,7 @@
+---
+- name: Ensure that the privoxy package is installed
+  tags: privoxy
+  package:
+    name: privoxy
+    state: present
+...

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,4 +1,7 @@
 ---
 privoxy_user: "{{ ansible_real_user_id }}"
 privoxy_group: "{{ ansible_real_group_id }}"
+privoxy_confdir: /usr/local/etc/privoxy
+privoxy_logdir: /usr/local/var/log/privoxy
+privoxy_user_manual: /usr/local/share/doc/privoxy/user-manual
 ...

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,0 +1,4 @@
+---
+privoxy_user: "{{ ansible_real_user_id }}"
+privoxy_group: "{{ ansible_real_group_id }}"
+...

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,4 @@
+---
+privoxy_user: "privoxy"
+privoxy_group: "privoxy"
+...

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,7 @@
 ---
 privoxy_user: "privoxy"
-privoxy_group: "privoxy"
+privoxy_group: "root"
+privoxy_confdir: /etc/privoxy
+privoxy_logdir: /var/log/privoxy
+privoxy_user_manual: /usr/share/doc/privoxy/user-manual
 ...


### PR DESCRIPTION
I have changed this role to use with Ubuntu.
I tested this on Ubuntu 20.04.

Note:
Moved three variables (`privoxy_confdir`, `privoxy_logdir`, `privoxy_user_manual`) to vars.
This is to switch default values depending on the operating system.
This gives higher priority to the default values.

I think the rare case to use this variable, is there any  problem?